### PR TITLE
Format prices for non-whole numbers

### DIFF
--- a/emails/Ordered/html.hbs
+++ b/emails/Ordered/html.hbs
@@ -42,7 +42,7 @@
             <tr style="font-size: 14px;">
               <td style="padding: 0 0 10px;">{{ this.description }}</td>
               <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.quantity }}</td>
-              <td style="padding: 0 0 10px; color: #555; text-align: right;">${{ this.amount }}.00</td>
+              <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.amount }}</td>
             </tr>
           {{/each}}
         </tbody>
@@ -56,7 +56,7 @@
                 <tbody>
                   <tr style="color: #555;">
                     <td style="padding-bottom: 5px;">Subtotal</td>
-                    <td style="text-align: right;">${{ order_total }}.00</td>
+                    <td style="text-align: right;">{{ order_total }}</td>
                   </tr>
                   <tr style="color: #555;">
                     <td style="padding-bottom: 5px;">Shipping</td>
@@ -64,7 +64,7 @@
                   </tr>
                   <tr style="font-weight: bold;">
                     <td>Total</td>
-                    <td style="text-align: right;">${{ order_total }}.00</td>
+                    <td style="text-align: right;">{{ order_total }}</td>
                   </tr>
                 </tbody>
               </table>

--- a/emails/Processed/html.hbs
+++ b/emails/Processed/html.hbs
@@ -23,7 +23,7 @@
             <tr style="font-size: 14px;">
               <td style="padding: 0 0 10px;">{{ this.description }}</td>
               <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.quantity }}</td>
-              <td style="padding: 0 0 10px; color: #555; text-align: right;">${{ this.amount }}.00</td>
+              <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.amount }}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/emails/Received/html.hbs
+++ b/emails/Received/html.hbs
@@ -23,7 +23,7 @@
             <tr style="font-size: 14px;">
               <td style="padding: 0 0 10px;">{{ this.description }}</td>
               <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.quantity }}</td>
-              <td style="padding: 0 0 10px; color: #555; text-align: right;">${{ this.amount }}.00</td>
+              <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.amount }}</td>
             </tr>
           {{/each}}
         </tbody>

--- a/emails/Shipped/html.hbs
+++ b/emails/Shipped/html.hbs
@@ -35,7 +35,7 @@
             <tr style="font-size: 14px;">
               <td style="padding: 0 0 10px;">{{ this.description }}</td>
               <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.quantity }}</td>
-              <td style="padding: 0 0 10px; color: #555; text-align: right;">${{ this.amount }}.00</td>
+              <td style="padding: 0 0 10px; color: #555; text-align: right;">{{ this.amount }}</td>
             </tr>
           {{/each}}
         </tbody>
@@ -49,7 +49,7 @@
                 <tbody>
                   <tr style="color: #555;">
                     <td style="padding-bottom: 5px;">Subtotal</td>
-                    <td style="text-align: right;">${{ order_total }}.00</td>
+                    <td style="text-align: right;">{{ order_total }}</td>
                   </tr>
                   <tr style="color: #555;">
                     <td style="padding-bottom: 5px;">Shipping</td>
@@ -57,7 +57,7 @@
                   </tr>
                   <tr style="font-weight: bold;">
                     <td>Total</td>
-                    <td style="text-align: right;">${{ order_total }}.00</td>
+                    <td style="text-align: right;">{{ order_total }}</td>
                   </tr>
                 </tbody>
               </table>

--- a/server/orders.js
+++ b/server/orders.js
@@ -35,7 +35,7 @@ const email = new Email({
 
 function sendEmail(status, order) {
   const items = order.items.slice(0,-2).map(o => {
-    o.amount = o.amount/100;
+    o.amount = (o.amount/100).toLocaleString('en-US', { style: 'currency', currency: 'USD' });
     return o;
   });
   const time = new Date(order.status_transitions.paid * 1000);
@@ -48,7 +48,7 @@ function sendEmail(status, order) {
       locals: {
         order: order,
         order_id: order.id.split("_")[1],
-        order_total: order.amount/100,
+        order_total: (order.amount/100).toLocaleString('en-US', { style: 'currency', currency: 'USD' }),
         order_date: `${time.getMonth()}/${time.getDate()}/${time.getFullYear()}`,
         items: items,
         config: config

--- a/src/components/cart/Cart.js
+++ b/src/components/cart/Cart.js
@@ -66,6 +66,7 @@ class Cart extends Component {
       totalPrice = this.state.items
         .map(i => (i.quantity*i.price))
         .reduce((a,b) => a+Number(b))
+        .toLocaleString('en-US', { style: 'currency', currency: 'USD' })
     }
     return (
       <PageWrapper>

--- a/src/components/cart/Cart.js
+++ b/src/components/cart/Cart.js
@@ -83,7 +83,7 @@ class Cart extends Component {
                 <RightSide>
                   <Subtotal>
                     <span>Subtotal</span>
-                    ${totalPrice}.00
+                    {totalPrice}
                   </Subtotal>
                   <Link to={`/checkout`} style={{ textDecoration: "none" }}>
                     <Button variant="raised" color="primary">Check Out</Button>

--- a/src/components/cart/CartSmall.js
+++ b/src/components/cart/CartSmall.js
@@ -37,6 +37,7 @@ class CartSmall extends Component {
       price = this.props.items
         .map(i => i.quantity*i.price)
         .reduce((a,b) => a+Number(b))
+        .toLocaleString('en-US', { style: 'currency', currency: 'USD' })
     }
     return (
       <Wrapper>
@@ -63,7 +64,7 @@ class CartSmall extends Component {
         <Divider style={{ margin: "20px 0" }}/>
           <Row>
             <span className="small-text">Subtotal</span>
-            <span className="black-text small-text">${price}</span>
+            <span className="black-text small-text">{price}</span>
           </Row>
           <Row>
             <span className="small-text">Shipping</span>
@@ -72,7 +73,7 @@ class CartSmall extends Component {
         <Divider style={{ margin: "20px 0" }}/>
           <Row>
             <span>Total</span>
-            <span className="black-text">${price}</span>
+            <span className="black-text">{price}</span>
           </Row>
       </Wrapper>
     );

--- a/src/components/cart/CartTable.js
+++ b/src/components/cart/CartTable.js
@@ -105,7 +105,7 @@ class CartTable extends Component {
                 />
               </td>
               <td>
-                ${d.quantity*d.price}
+                ${(d.quantity*d.price).toFixed(2)}
               </td>
               <td>
                 <Remove onClick={() => this.props.removeItem(i)}>✕</Remove>

--- a/src/components/cart/CartTable.js
+++ b/src/components/cart/CartTable.js
@@ -98,7 +98,10 @@ class CartTable extends Component {
               <td>
                 <TextField
                   value={d.quantity}
-                  onChange={(e) => this.props.updateCount(i, e.target.value)} 
+                  onChange={(e) => {
+                    if (e.target.value < 0) e.target.value = 0;
+                    this.props.updateCount(i, e.target.value)}
+                  }
                   type="number"
                   margin="none"
                   style={{ width: "40px" }}


### PR DESCRIPTION
Heeeey gurl I have some fixes for you. 🍍 

Found some strangeness with the way prices that were not whole numbers are displayed in the cart and customer emails. Where `${totalPrice}.00` was being used to display the subtotal, prices such as `3.2` would display as `$3.2.00`. The prices were also not being constrained to 2 decimal points. Switched to using `toLocaleString()` and `toFixed(2)`

**broken thing 1:**
<img width="370" alt="screen shot 2018-11-21 at 1 00 52 pm" src="https://user-images.githubusercontent.com/3952537/48865744-86623980-ed9e-11e8-9128-4e4cfbbd5000.png">

**broken thing 2:**
<img width="537" alt="screen shot 2018-11-21 at 1 14 21 pm" src="https://user-images.githubusercontent.com/3952537/48866036-6717dc00-ed9f-11e8-8039-adb9bdae5551.png">

**this fixes these dollar decimal display issues in the cart:**

<img width="416" alt="screen shot 2018-11-21 at 1 20 51 pm" src="https://user-images.githubusercontent.com/3952537/48865741-85c9a300-ed9e-11e8-9bfc-cead2b780467.png">

**and in fixes them in the email templates:**
<img width="370" alt="screen shot 2018-11-21 at 2 43 35 pm" src="https://user-images.githubusercontent.com/3952537/48865739-85c9a300-ed9e-11e8-80ff-418aad34a8bf.png">


--

addition 12/3:
* also disallowed negative values in the cart

<img width="486" alt="screen shot 2018-12-03 at 9 20 04 pm" src="https://user-images.githubusercontent.com/3952537/49414484-92a4aa00-f741-11e8-8564-7781a46625db.png">
